### PR TITLE
Enable static volume binding in Prowlar chart

### DIFF
--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.23.0-0"
 name: prowlarr
 description: prowlarr helm chart for Kubernetes
 type: application
-version: 0.2.5
+version: 0.3.0
 # image: ghcr.io/onedr0p/prowlarr
 appVersion: "1.17.2"
 maintainers:

--- a/charts/prowlarr/README.md
+++ b/charts/prowlarr/README.md
@@ -1,6 +1,6 @@
 # prowlarr
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.17.2](https://img.shields.io/badge/AppVersion-1.17.2-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.17.2](https://img.shields.io/badge/AppVersion-1.17.2-informational?style=flat-square)
 
 prowlarr helm chart for Kubernetes
 
@@ -42,7 +42,7 @@ helm repo add adminafk https://helm-charts.adminafk.fr
 | config.persistence.annotations | object | `{}` | Annotations for PVCs |
 | config.persistence.name | string | `""` | Config name |
 | config.persistence.size | string | `"5Gi"` | Size of persistent disk |
-| config.persistence.volumeName | string | `""` | bind to existing volumes |
+| config.persistence.volumeName | string | `""` | Name of the permanent volume to reference in the claim. Can be used to bind to existing volumes. |
 | extraEnv | list | `[]` | Environment variables to add to the prowlarr pods |
 | extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the prowlarr pods |
 | fullnameOverride | string | `""` |  |

--- a/charts/prowlarr/README.md
+++ b/charts/prowlarr/README.md
@@ -37,11 +37,12 @@ helm repo add adminafk https://helm-charts.adminafk.fr
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| config | object | `{"persistence":{"accessModes":["ReadWriteOnce"],"annotations":{},"name":"","size":"5Gi"}}` | Creating PVC to store configuration |
+| config | object | `{"persistence":{"accessModes":["ReadWriteOnce"],"annotations":{},"name":"","size":"5Gi","volumeName":""}}` | Creating PVC to store configuration |
 | config.persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes of persistent disk |
 | config.persistence.annotations | object | `{}` | Annotations for PVCs |
 | config.persistence.name | string | `""` | Config name |
 | config.persistence.size | string | `"5Gi"` | Size of persistent disk |
+| config.persistence.volumeName | string | `""` | bind to existing volumes |
 | extraEnv | list | `[]` | Environment variables to add to the prowlarr pods |
 | extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the prowlarr pods |
 | fullnameOverride | string | `""` |  |

--- a/charts/prowlarr/templates/persistentvolumeclaim.yaml
+++ b/charts/prowlarr/templates/persistentvolumeclaim.yaml
@@ -9,6 +9,9 @@ spec:
   accessModes:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.config.persistence.volumeName }}
+  volumeName: {{ .Values.config.persistence.volumeName }}
+  {{- end }}
   {{- with .Values.config.persistence.storageClass }}
   storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
   {{- end }}

--- a/charts/prowlarr/values.yaml
+++ b/charts/prowlarr/values.yaml
@@ -68,6 +68,9 @@ config:
       - ReadWriteOnce
     # -- Config name
     name: ""
+    # -- Name of the permanent volume to reference in the claim. Can be used
+    # -- bind to existing volumes
+    volumeName: ""
 
 ingress:
   enabled: false

--- a/charts/prowlarr/values.yaml
+++ b/charts/prowlarr/values.yaml
@@ -68,8 +68,8 @@ config:
       - ReadWriteOnce
     # -- Config name
     name: ""
-    # -- Name of the permanent volume to reference in the claim. Can be used
-    # -- bind to existing volumes
+    # -- Name of the permanent volume to reference in the claim.
+    # Can be used to bind to existing volumes.
     volumeName: ""
 
 ingress:


### PR DESCRIPTION
**Description**
This PR adds the option to specify `volumeName` in the PVC of Prowlarr, this allows use existing volumes in the PVC,

# Linked issue(s)
<!--- If your PR fully resolves and should automatically close the linked issue, use Fixes. Otherwise, use Relates --->
Fixes #0000 | Relates #0000

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->
