### PR TITLE
Fix: add env HOMEPAGE_ALLOWED_HOSTS, FEAT: add configs in configmap 

### DIFF
--- a/charts/homepage/README.md
+++ b/charts/homepage/README.md
@@ -38,6 +38,15 @@ tions.githubusercontent.com
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| config.bookmarksYaml | string | `"---\n- Developer:\n    - Github:\n        - abbr: GH\n          href: https://github.com/\n\n- Social:\n    - Reddit:\n        - icon: reddit.png\n          href: https://reddit.com/\n          description: The front page of the internet\n\n- Entertainment:\n    - YouTube:\n        - abbr: YT\n          href: https://youtube.com/\n"` |  |
+| config.customCss | string | `""` |  |
+| config.customJs | string | `""` |  |
+| config.dockerYaml | string | `""` |  |
+| config.kubernetesYaml | string | `"---\nmode: cluster\n"` |  |
+| config.servicesYaml | string | `"---\n- My First Group:\n    - My First Service:\n        href: http://localhost/\n        description: Homepage is awesome\n\n- My Second Group:\n    - My Second Service:\n        href: http://localhost/\n        description: Homepage is the best\n\n- My Third Group:\n    - My Third Service:\n        href: http://localhost/\n        description: Homepage is 😎\n"` |  |
+| config.settingsYaml | string | `"---\ntitle: My Awesome Homepage\ndescription: A description of my awesome homepage\ntheme: dark\nlanguage: en\n"` |  |
+| config.widgetsYaml | string | `"---\n- kubernetes:\n    cluster:\n      show: true\n      cpu: true\n      memory: true\n      showLabel: true\n      label: \"cluster\"\n    nodes:\n      show: true\n      cpu: true\n      memory: true\n      showLabel: true\n- resources:\n    backend: resources\n    expanded: true\n    cpu: true\n    memory: true\n    network: default\n- search:\n    provider: duckduckgo\n    target: _blank\n"` |  |
+| envBaseUrl | string | `"homepage.example.com"` | Required! IP or Url - without http/https   Environment variables is a comma-separated (no spaces) list of allowed hosts (sometimes with the port)  that can host your homepage install.  <https://gethomepage.dev/installation/#homepage_allowed_hosts> |
 | extraEnv | list | `[]` | Environment variables to add to the kea-exporter pods |
 | extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the kea-exporter pods |
 | fullnameOverride | string | `""` |  |

--- a/charts/homepage/templates/configmap.yaml
+++ b/charts/homepage/templates/configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "homepage.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "homepage.labels" . | nindent 4 }}
+data:
+  kubernetes.yaml: |
+    {{ .Values.config.kubernetesYaml | nindent 4 }}
+  settings.yaml: |
+    {{ .Values.config.settingsYaml | nindent 4 }}
+  custom.css: |
+    {{ .Values.config.customCss | nindent 4 }}
+  custom.js: |
+    {{ .Values.config.customJs | nindent 4 }}
+  bookmarks.yaml: |
+    {{ .Values.config.bookmarksYaml | nindent 4 }}
+  services.yaml: |
+    {{ .Values.config.servicesYaml | nindent 4 }}
+  widgets.yaml: |
+    {{ .Values.config.widgetsYaml | nindent 4 }}
+  docker.yaml: |
+    {{ .Values.config.dockerYaml | nindent 4 }}

--- a/charts/homepage/templates/deployment.yaml
+++ b/charts/homepage/templates/deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: {{ .Values.securityContext.runAsUser | quote }}
             - name: PGID
               value: {{ .Values.securityContext.runAsGroup | quote }}
+            - name: HOMEPAGE_ALLOWED_HOSTS
+              value: {{ .Values.envBaseUrl | quote }}
           {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/homepage/values.yaml
+++ b/charts/homepage/values.yaml
@@ -12,6 +12,11 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- Required! IP or Url - without http/https  
+# Environment variables is a comma-separated (no spaces) list of allowed hosts (sometimes with the port) 
+# that can host your homepage install.  <https://gethomepage.dev/installation/#homepage_allowed_hosts>
+envBaseUrl: homepage.example.com
+
 # -- Environment variables to add to the kea-exporter pods
 extraEnv: []
 # -- Environment variables from secrets or configmaps to add to the kea-exporter pods
@@ -58,6 +63,11 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+    ### Consider sticky-session if replicaCount > 1
+    # nginx.ingress.kubernetes.io/affinity: "cookie"
+    # nginx.ingress.kubernetes.io/session-cookie-name: "sample-cookie"
+    # nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
+    # nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
   hosts:
     - host: chart-example.local
       paths:
@@ -101,3 +111,88 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+config:
+  customJs: ""
+  # customJs: |
+  #   This is a multiline value, aka heredoc.
+
+  customCss: ""
+  # customCss: |
+  #   This is a multiline value, aka heredoc.
+
+  bookmarksYaml: |
+    ---
+    - Developer:
+        - Github:
+            - abbr: GH
+              href: https://github.com/
+
+    - Social:
+        - Reddit:
+            - icon: reddit.png
+              href: https://reddit.com/
+              description: The front page of the internet
+
+    - Entertainment:
+        - YouTube:
+            - abbr: YT
+              href: https://youtube.com/
+
+  dockerYaml: ""
+  # dockerYaml: |
+  #   ---
+  #   This is a multiline value, aka heredoc.
+
+  kubernetesYaml: |
+    ---
+    mode: cluster
+
+  servicesYaml: |
+    ---
+    - My First Group:
+        - My First Service:
+            href: http://localhost/
+            description: Homepage is awesome
+  
+    - My Second Group:
+        - My Second Service:
+            href: http://localhost/
+            description: Homepage is the best
+  
+    - My Third Group:
+        - My Third Service:
+            href: http://localhost/
+            description: Homepage is 😎
+  
+  settingsYaml: |
+    ---
+    title: My Awesome Homepage
+    description: A description of my awesome homepage
+    theme: dark
+    language: en
+  
+  widgetsYaml: |
+    ---
+    - kubernetes:
+        cluster:
+          show: true
+          cpu: true
+          memory: true
+          showLabel: true
+          label: "cluster"
+        nodes:
+          show: true
+          cpu: true
+          memory: true
+          showLabel: true
+    - resources:
+        backend: resources
+        expanded: true
+        cpu: true
+        memory: true
+        network: default
+    - search:
+        provider: duckduckgo
+        target: _blank
+  


### PR DESCRIPTION
**Description**

Homepage will not start without set env variable HOMEPAGE_ALLOWED_HOSTS
<https://gethomepage.dev/installation/#homepage_allowed_hosts>

Added config map witch contains all config files. So it can be managed directly from helm chart.

**Checklist**
- [x] End user documentation updated
