### PR TITLE
feat(qbittorrent)!: native gluetun sidecar + lifecycle passthrough

### DIFF
--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.23.0-0"
 name: qbittorrent
 description: qbittorrent helm chart for Kubernetes
 type: application
-version: 6.1.0
+version: 7.0.0
 # image: ghcr.io/home-operations/qbittorrent
 appVersion: "5.2.0"
 maintainers:

--- a/charts/qbittorrent/README.md
+++ b/charts/qbittorrent/README.md
@@ -1,6 +1,6 @@
 # qbittorrent
 
-![Version: 6.1.0](https://img.shields.io/badge/Version-6.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.2.0](https://img.shields.io/badge/AppVersion-5.2.0-informational?style=flat-square)
+![Version: 7.0.0](https://img.shields.io/badge/Version-7.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.2.0](https://img.shields.io/badge/AppVersion-5.2.0-informational?style=flat-square)
 
 qbittorrent helm chart for Kubernetes
 
@@ -33,7 +33,7 @@ helm install qbittorrent oci://ghcr.io/m0nsterrr/helm-charts/qbittorrent
 Verify the signature with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) :
 
 ```console
-cosign verify ghcr.io/m0nsterrr/helm-charts/qbittorrent:6.1.0 --certificate-identity-regexp=^https://github.com/M0NsTeRRR/helm-charts.*$ --certificate-oidc-issuer=https://token.ac
+cosign verify ghcr.io/m0nsterrr/helm-charts/qbittorrent:7.0.0 --certificate-identity-regexp=^https://github.com/M0NsTeRRR/helm-charts.*$ --certificate-oidc-issuer=https://token.ac
 tions.githubusercontent.com
 ```
 
@@ -67,7 +67,7 @@ tions.githubusercontent.com
 | qbittorrent.extraEnv | list | `[]` | Environment variables to add to the qbittorrent pods |
 | qbittorrent.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the qbittorrent pods |
 | qbittorrent.fullnameOverride | string | `""` |  |
-| qbittorrent.gluetun | object | `{"enabled":false,"extraEnv":[],"extraEnvFrom":[],"image":{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"qmcgaw/gluetun","sha":"","tag":"v3.41.1"},"resources":{"limits":{"devic.es":1}},"securityContext":{"capabilities":{"add":["NET_ADMIN"]}},"volumeMounts":[]}` | Gluetun sidecar |
+| qbittorrent.gluetun | object | `{"enabled":false,"extraEnv":[],"extraEnvFrom":[],"image":{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"qmcgaw/gluetun","sha":"","tag":"v3.41.1"},"resources":{"limits":{"devic.es/tun":1}},"securityContext":{"capabilities":{"add":["NET_ADMIN"]}},"volumeMounts":[]}` | Gluetun sidecar |
 | qbittorrent.image.pullPolicy | string | `"IfNotPresent"` |  |
 | qbittorrent.image.registry | string | `"ghcr.io"` |  |
 | qbittorrent.image.repository | string | `"home-operations/qbittorrent"` |  |

--- a/charts/qbittorrent/templates/deployment.yaml
+++ b/charts/qbittorrent/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- $supportsSidecarContainers := semverCompare ">=1.29.0-0" .Capabilities.KubeVersion.Version }}
       {{- with .Values.qbittorrent.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
@@ -86,7 +87,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
-        {{- if .Values.qbittorrent.gluetun.enabled }}
+        {{- if and .Values.qbittorrent.gluetun.enabled (not $supportsSidecarContainers) }}
         - name: gluten
           securityContext:
             {{- toYaml .Values.qbittorrent.gluetun.securityContext | nindent 12 }}
@@ -97,7 +98,7 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.qbittorrent.gluetun.image.pullPolicy }}
           ports:
-            - name: http
+            - name: gluetun-http
               containerPort: 8888
               protocol: TCP
             - name: shadowsocks-tcp
@@ -191,6 +192,63 @@ spec:
         {{- with .Values.qbittorrent.extraContainers }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if and .Values.qbittorrent.gluetun.enabled $supportsSidecarContainers }}
+      initContainers:
+        - name: gluten
+          restartPolicy: Always
+          securityContext:
+            {{- toYaml .Values.qbittorrent.gluetun.securityContext | nindent 12 }}
+          {{- if .Values.qbittorrent.gluetun.image.sha }}
+          image: "{{ .Values.qbittorrent.gluetun.image.registry }}/{{ .Values.qbittorrent.gluetun.image.repository }}:{{ .Values.qbittorrent.gluetun.image.tag }}@sha256:{{ .Values.qbittorrent.gluetun.image.sha }}"
+          {{- else }}
+          image: "{{ .Values.qbittorrent.gluetun.image.registry }}/{{ .Values.qbittorrent.gluetun.image.repository }}:{{ .Values.qbittorrent.gluetun.image.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.qbittorrent.gluetun.image.pullPolicy }}
+          ports:
+            - name: gluetun-http
+              containerPort: 8888
+              protocol: TCP
+            - name: shadowsocks-tcp
+              containerPort: 8388
+              protocol: TCP
+            - name: shadowsocks-udp
+              containerPort: 8388
+              protocol: UDP
+          startupProbe:
+            exec:
+              command:
+                - /gluetun-entrypoint
+                - healthcheck
+          livenessProbe:
+            exec:
+              command:
+                - /gluetun-entrypoint
+                - healthcheck
+          readinessProbe:
+            exec:
+              command:
+                - /gluetun-entrypoint
+                - healthcheck
+          # https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/kubernetes.md#adding-ipv6-rule--file-exists
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "(ip rule del table 51820; ip -6 rule del table 51820) || true"]
+          resources:
+            {{- toYaml .Values.qbittorrent.gluetun.resources | nindent 12 }}
+          {{- with .Values.qbittorrent.gluetun.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.qbittorrent.gluetun.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.qbittorrent.gluetun.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
       {{- if or .Values.qbittorrent.config.persistence.enabled .Values.qbittorrent.volumes }}
       volumes:
       {{- if .Values.qbittorrent.config.persistence.enabled }}

--- a/charts/qbittorrent/values.yaml
+++ b/charts/qbittorrent/values.yaml
@@ -179,7 +179,7 @@ qbittorrent:
           - NET_ADMIN
     resources:
       limits:
-        devic.es: 1
+        "devic.es/tun": 1
 
   # -- Prometheus-qbittorrent-exporter sidecar
   prometheusQbittorrentExporter:


### PR DESCRIPTION
When `qbittorrent.gluetun.enabled` is true and the cluster is Kubernetes 1.29+, render gluetun as a Kubernetes native sidecar (an init container with `restartPolicy: Always`) so the existing gluetun `startupProbe` gates qbittorrent start-up. Older clusters keep the existing peer-container layout unchanged.

## Description

- Add `$gluetunNative`, true when `qbittorrent.gluetun.enabled` is set and `.Capabilities.KubeVersion.Version` matches `>=1.29.0-0` (`semverCompare`).
- **Native path:** gluetun is the first entry of `spec.initContainers`, with `restartPolicy: Always`. The existing `startupProbe` (`/gluetun-entrypoint healthcheck`) blocks qbittorrent start-up until the VPN is up.
- **Legacy path:** unchanged. gluetun stays in `spec.containers` between qbittorrent and prometheus/extra containers.
- **`qbittorrent.gluetun.resources.limits.devic.es: 1` -> `devic.es/tun: 1`:** the bare `devic.es` key was unqualified and rejected by the apiserver. The qualified key matches what `squat/generic-device-plugin` 0.2.0 advertises on nodes.
- **Chart `6.1.0 → 7.0.0`** (major, required by the breaking port rename below). `appVersion` unchanged. `kubeVersion` stays at `>=1.23.0-0`.

### BREAKING CHANGE

The gluetun container port has been renamed from `http` to `gluetun-http` to avoid a name collision with qbittorrent's `http` port. With gluetun as an init container, `targetPort: http` on `Service/<release>-web` was resolving to the gluetun admin port (`8888`) instead of qbittorrent (`8080`). 

**Migration:** replace `http` with `gluetun-http` in any external reference to the gluetun port (ServiceMonitor / NetworkPolicy / extraContainers probes), or switch to a numeric reference (`8888`).

## Motivation and Context

Running gluetun as a peer container hits a startup race in my homelab. I found that qbittorrent occasionally starts before `tun0` exists and binds/listens incorrectly. Kubernetes 1.29+ supports native sidecars (init containers with `restartPolicy: Always`). Moving gluetun onto that path lets the existing `startupProbe` gate qbittorrent without forcing a higher `kubeVersion` floor. 

## How Has This Been Tested?

- `helm lint charts/qbittorrent`
- `helm template` with `qbittorrent.gluetun.enabled=true`:
  - `--kube-version 1.28` -> gluetun rendered only under **`containers`** (no `initContainers`, no `restartPolicy`).
  - `--kube-version 1.29` -> gluetun under **`initContainers`** with **`restartPolicy: Always`** after the main container list.
- I've been deploying from this branch into my k3s homelab cluster (v1.35.4) with `gluetun.enabled=true` and confirmed qbittorrent starts only after gluetun’s startup probe succeeds.

## Screenshots / Logs (if applicable)

<img width="1654" height="122" alt="Screenshot 2026-05-11 at 2 01 49 PM" src="https://github.com/user-attachments/assets/b57762a9-a74a-4644-afc2-b2b7c255e372" />


## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] I have read and followed the contribution [guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request