### PR TITLE
fix(homepage): use /api/healthcheck for liveness/readiness probes

### DIFF
--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.23.0-0"
 name: homepage
 description: homepage helm chart for Kubernetes
 type: application
-version: 4.12.2
+version: 4.12.3
 # image: ghcr.io/gethomepage/homepage
 appVersion: "v1.13.2"
 maintainers:

--- a/charts/homepage/README.md
+++ b/charts/homepage/README.md
@@ -1,6 +1,6 @@
 # homepage
 
-![Version: 4.12.2](https://img.shields.io/badge/Version-4.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.13.2](https://img.shields.io/badge/AppVersion-v1.13.2-informational?style=flat-square)
+![Version: 4.12.3](https://img.shields.io/badge/Version-4.12.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.13.2](https://img.shields.io/badge/AppVersion-v1.13.2-informational?style=flat-square)
 
 homepage helm chart for Kubernetes
 
@@ -29,7 +29,7 @@ helm install homepage oci://ghcr.io/m0nsterrr/helm-charts/homepage
 Verify the signature with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) :
 
 ```console
-cosign verify ghcr.io/m0nsterrr/helm-charts/homepage:4.12.2 --certificate-identity-regexp=^https://github.com/M0NsTeRRR/helm-charts.*$ --certificate-oidc-issuer=https://token.ac
+cosign verify ghcr.io/m0nsterrr/helm-charts/homepage:4.12.3 --certificate-identity-regexp=^https://github.com/M0NsTeRRR/helm-charts.*$ --certificate-oidc-issuer=https://token.ac
 tions.githubusercontent.com
 ```
 

--- a/charts/homepage/templates/deployment.yaml
+++ b/charts/homepage/templates/deployment.yaml
@@ -48,11 +48,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/healthcheck
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/healthcheck
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
## Description

The `homepage` chart's liveness and readiness probes targeted `httpGet` on `/`. This PR points them at the application's dedicated `/api/healthcheck` endpoint instead.

Chart version bumped 4.12.2 → 4.12.3; `README.md` regenerated with helm-docs.

## Motivation and Context

`/` is the homepage dashboard root: a Next.js server-side-rendered page that fans out to the configured widget backends (Kubernetes, Grafana, etc.). Under load its render time can exceed the probe's (default 1s) `timeoutSeconds`, so three consecutive failures cause the kubelet to SIGKILL and restart an otherwise healthy pod (exit code 137).

`/api/healthcheck` is the application's dedicated health endpoint (also used by the upstream image's Docker `HEALTHCHECK`), so it responds immediately without rendering the dashboard — a far more appropriate probe target.

## How Has This Been Tested?

- `helm lint charts/homepage` passes.
- `helm template` renders both probes against `/api/healthcheck`.
- `helm-docs` regenerated `README.md`; no diff drift.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.