### PR TITLE
feat(homepage): allow the pod IP so orchestrator probes pass host validation

### DIFF
--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.23.0-0"
 name: homepage
 description: homepage helm chart for Kubernetes
 type: application
-version: 4.12.3
+version: 4.13.0
 # image: ghcr.io/gethomepage/homepage
 appVersion: "v1.13.2"
 maintainers:

--- a/charts/homepage/README.md
+++ b/charts/homepage/README.md
@@ -1,6 +1,6 @@
 # homepage
 
-![Version: 4.12.3](https://img.shields.io/badge/Version-4.12.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.13.2](https://img.shields.io/badge/AppVersion-v1.13.2-informational?style=flat-square)
+![Version: 4.13.0](https://img.shields.io/badge/Version-4.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.13.2](https://img.shields.io/badge/AppVersion-v1.13.2-informational?style=flat-square)
 
 homepage helm chart for Kubernetes
 
@@ -29,7 +29,7 @@ helm install homepage oci://ghcr.io/m0nsterrr/helm-charts/homepage
 Verify the signature with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) :
 
 ```console
-cosign verify ghcr.io/m0nsterrr/helm-charts/homepage:4.12.3 --certificate-identity-regexp=^https://github.com/M0NsTeRRR/helm-charts.*$ --certificate-oidc-issuer=https://token.ac
+cosign verify ghcr.io/m0nsterrr/helm-charts/homepage:4.13.0 --certificate-identity-regexp=^https://github.com/M0NsTeRRR/helm-charts.*$ --certificate-oidc-issuer=https://token.ac
 tions.githubusercontent.com
 ```
 

--- a/charts/homepage/templates/_helpers.tpl
+++ b/charts/homepage/templates/_helpers.tpl
@@ -83,6 +83,9 @@ and custom allowed hosts for homepage.allowedHosts
 {{- $fullFQDN := printf "%s.%s.svc.cluster.local" $fullName $namespace -}}
 {{- $serviceList = append $serviceList $fullFQDN -}}
 
+{{- /* Allow the pod IP so orchestrator probes (which send it as the Host header) pass host validation; POD_IP is injected via the downward API and expanded by Kubernetes at runtime */ -}}
+{{- $serviceList = append $serviceList "$(POD_IP):3000" -}}
+
 {{- /* Add custom allowed hosts from values.yaml */ -}}
 {{- range $host := .Values.config.allowedHosts -}}
   {{- $serviceList = append $serviceList $host -}}

--- a/charts/homepage/templates/deployment.yaml
+++ b/charts/homepage/templates/deployment.yaml
@@ -61,6 +61,10 @@ spec:
               value: {{ .Values.securityContext.runAsUser | quote }}
             - name: PGID
               value: {{ .Values.securityContext.runAsGroup | quote }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: HOMEPAGE_ALLOWED_HOSTS
               value: {{ include "homepage.allowedHosts" . }}
           {{- with .Values.extraEnv }}


### PR DESCRIPTION
## Description

Inject `POD_IP` into the homepage container via the Kubernetes downward API and append `$(POD_IP):3000` to the generated `HOMEPAGE_ALLOWED_HOSTS` list. Kubernetes expands the reference at runtime, so the pod's own IP is accepted by homepage's host validation while validation stays enforced for every other host.

Chart version bumped 4.12.2 → 4.13.0; `README.md` regenerated with helm-docs.

## Motivation and Context

homepage's host-validation middleware now matches all routes and returns **HTTP 400** for any request whose `Host` header isn't in `HOMEPAGE_ALLOWED_HOSTS`. Kubernetes liveness/readiness probes (and Docker healthchecks) send the **pod/container IP** as the `Host` header:

```
error: Host validation failed for: 192.168.10.106:3000. Hint: Set the HOMEPAGE_ALLOWED_HOSTS environment variable to allow requests from this host / port.
```

The probe then fails and the kubelet restarts the container in a crash loop. The pod IP is dynamic, so it can't be added to `config.allowedHosts` ahead of time, and the only workarounds are blunt (`HOMEPAGE_ALLOWED_HOSTS=*` disables validation entirely). The downward API lets the chart add exactly the pod's own IP, automatically.

## How Has This Been Tested?

- `helm lint charts/homepage` passes.
- `helm template` renders `HOMEPAGE_ALLOWED_HOSTS=<fqdns>,$(POD_IP):3000` with the `POD_IP` env declared **before** it (required for `$(VAR)` expansion).
- **Verified live on a real AKS cluster** (equivalent manual patch): the kubelet probe to `/api/healthcheck` with `Host: <pod-IP>:3000` returns `200`, the pod runs `Ready 1/1` with 0 restarts, and `HOMEPAGE_ALLOWED_HOSTS` resolves to `...,192.168.10.106:3000` inside the container.
- `helm-docs` regenerated `README.md`; no drift.

## Types of Changes

- [x] New feature (non-breaking change which adds functionality)

The pod IP is added unconditionally. Happy to gate it behind a value (e.g. `config.allowPodIp`) if you'd prefer. The port is hardcoded to `3000` to match the chart's `containerPort`.

## Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.