### PR TITLE
feat(qbittorrent): support labels on services

### DIFF
--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.23.0-0"
 name: qbittorrent
 description: qbittorrent helm chart for Kubernetes
 type: application
-version: 7.0.3
+version: 7.1.0
 # image: ghcr.io/home-operations/qbittorrent
 appVersion: "5.2.3"
 maintainers:

--- a/charts/qbittorrent/README.md
+++ b/charts/qbittorrent/README.md
@@ -1,6 +1,6 @@
 # qbittorrent
 
-![Version: 7.0.3](https://img.shields.io/badge/Version-7.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.2.3](https://img.shields.io/badge/AppVersion-5.2.3-informational?style=flat-square)
+![Version: 7.1.0](https://img.shields.io/badge/Version-7.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.2.3](https://img.shields.io/badge/AppVersion-5.2.3-informational?style=flat-square)
 
 qbittorrent helm chart for Kubernetes
 
@@ -33,7 +33,7 @@ helm install qbittorrent oci://ghcr.io/m0nsterrr/helm-charts/qbittorrent
 Verify the signature with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) :
 
 ```console
-cosign verify ghcr.io/m0nsterrr/helm-charts/qbittorrent:7.0.3 --certificate-identity-regexp=^https://github.com/M0NsTeRRR/helm-charts.*$ --certificate-oidc-issuer=https://token.ac
+cosign verify ghcr.io/m0nsterrr/helm-charts/qbittorrent:7.1.0 --certificate-identity-regexp=^https://github.com/M0NsTeRRR/helm-charts.*$ --certificate-oidc-issuer=https://token.ac
 tions.githubusercontent.com
 ```
 
@@ -115,9 +115,11 @@ tions.githubusercontent.com
 | qbittorrent.securityContext.runAsUser | int | `65534` |  |
 | qbittorrent.securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | qbittorrent.service.torrent.annotations | object | `{}` | Annotations to add to the torrent service |
+| qbittorrent.service.torrent.labels | object | `{}` | Labels to add to the torrent service |
 | qbittorrent.service.torrent.port | int | `8388` |  |
 | qbittorrent.service.torrent.type | string | `"ClusterIP"` |  |
 | qbittorrent.service.web.annotations | object | `{}` | Annotations to add to the web service |
+| qbittorrent.service.web.labels | object | `{}` | Labels to add to the web service |
 | qbittorrent.service.web.port | int | `80` |  |
 | qbittorrent.service.web.type | string | `"ClusterIP"` |  |
 | qbittorrent.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/qbittorrent/templates/torrentservice.yaml
+++ b/charts/qbittorrent/templates/torrentservice.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "qbittorrent.labels" . | nindent 4 }}
+    {{- with .Values.qbittorrent.service.torrent.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.qbittorrent.service.torrent.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/qbittorrent/templates/webservice.yaml
+++ b/charts/qbittorrent/templates/webservice.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "qbittorrent.labels" . | nindent 4 }}
+    {{- with .Values.qbittorrent.service.web.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.qbittorrent.service.web.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/qbittorrent/values.yaml
+++ b/charts/qbittorrent/values.yaml
@@ -61,11 +61,15 @@ qbittorrent:
       port: 80
       # -- Annotations to add to the web service
       annotations: {}
+      # -- Labels to add to the web service
+      labels: {}
     torrent:
       type: ClusterIP
       port: 8388
       # -- Annotations to add to the torrent service
       annotations: {}
+      # -- Labels to add to the torrent service
+      labels: {}
 
   # -- Creating PVC to store configuration
   config:


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

I use this chart and have noticed that labels can not be set for *web* and *torrent* service, so I added this :).

<!--- Describe your changes in detail -->

## Motivation and Context

The change is needed so labels can be set on the *web* and *torrent* services.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

It was tested using `helm lint` and `helm install --dry-run` (output below)

<!--- Please describe in detail how you tested your changes. -->
```bash
➜  helm-charts git:(qbittorrent-service-labels) ✗ helm install charts/qbittorrent --set qbittorrent.service.torrent.labels.am-here=i-am-label --set qbittorrent.service.web.labels.am-here=i-am-label --values charts/qbittorrent/values.yaml --generate-name --dry-run
NAME: qbittorrent-1783882233
LAST DEPLOYED: Sun Jul 12 20:50:33 2026
NAMESPACE: default
STATUS: pending-install
REVISION: 1
HOOKS:
---
# Source: qbittorrent/templates/tests/test-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "qbittorrent-1783882233-test-connection"
  namespace: default
  labels:
    helm.sh/chart: qbittorrent-7.1.0
    app.kubernetes.io/name: qbittorrent
    app.kubernetes.io/instance: qbittorrent-1783882233
    app.kubernetes.io/version: "5.2.3"
    app.kubernetes.io/part-of: qbittorrent
    app.kubernetes.io/managed-by: Helm
  annotations:
    "helm.sh/hook": test
spec:
  containers:
    - name: wget
      image: busybox
      command: ['wget']
      args: ['qbittorrent-1783882233:']
  restartPolicy: Never
MANIFEST:
---
# Source: qbittorrent/templates/generic-device-plugin/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: qbittorrent-1783882233-generic-device-plugin
  namespace: default
  labels:
    helm.sh/chart: qbittorrent-7.1.0
    app.kubernetes.io/name: generic-device-plugin
    app.kubernetes.io/instance: qbittorrent-1783882233
    app.kubernetes.io/version: "5.2.3"
    app.kubernetes.io/part-of: qbittorrent
    app.kubernetes.io/managed-by: Helm
automountServiceAccountToken: true
---
# Source: qbittorrent/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: qbittorrent-1783882233
  namespace: default
  labels:
    helm.sh/chart: qbittorrent-7.1.0
    app.kubernetes.io/name: qbittorrent
    app.kubernetes.io/instance: qbittorrent-1783882233
    app.kubernetes.io/version: "5.2.3"
    app.kubernetes.io/part-of: qbittorrent
    app.kubernetes.io/managed-by: Helm
automountServiceAccountToken: true
---
# Source: qbittorrent/templates/persistentvolumeclaim.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: qbittorrent-1783882233-config
  namespace: default
  labels:
    helm.sh/chart: qbittorrent-7.1.0
    app.kubernetes.io/name: qbittorrent
    app.kubernetes.io/instance: qbittorrent-1783882233
    app.kubernetes.io/version: "5.2.3"
    app.kubernetes.io/part-of: qbittorrent
    app.kubernetes.io/managed-by: Helm
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: "5Gi"
---
# Source: qbittorrent/templates/torrentservice.yaml
apiVersion: v1
kind: Service
metadata:
  name: qbittorrent-1783882233-torrent
  namespace: default
  labels:
    helm.sh/chart: qbittorrent-7.1.0
    app.kubernetes.io/name: qbittorrent
    app.kubernetes.io/instance: qbittorrent-1783882233
    app.kubernetes.io/version: "5.2.3"
    app.kubernetes.io/part-of: qbittorrent
    app.kubernetes.io/managed-by: Helm
    am-here: i-am-label
spec:
  type: ClusterIP
  ports:
    - port: 8388
      targetPort: torrent-tcp
      protocol: TCP
      name: torrent-tcp
    - port: 8388
      targetPort: torrent-udp
      protocol: UDP
      name: torrent-udp
  selector:
    app.kubernetes.io/name: qbittorrent
    app.kubernetes.io/instance: qbittorrent-1783882233
  ipFamilyPolicy: PreferDualStack
---
# Source: qbittorrent/templates/webservice.yaml
apiVersion: v1
kind: Service
metadata:
  name: qbittorrent-1783882233-web
  namespace: default
  labels:
    helm.sh/chart: qbittorrent-7.1.0
    app.kubernetes.io/name: qbittorrent
    app.kubernetes.io/instance: qbittorrent-1783882233
    app.kubernetes.io/version: "5.2.3"
    app.kubernetes.io/part-of: qbittorrent
    app.kubernetes.io/managed-by: Helm
    am-here: i-am-label
spec:
  type: ClusterIP
  ports:
    - port: 80
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: qbittorrent
    app.kubernetes.io/instance: qbittorrent-1783882233
  ipFamilyPolicy: PreferDualStack
---
# Source: qbittorrent/templates/generic-device-plugin/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: qbittorrent-1783882233-generic-device-plugin
  namespace: default
  labels:
    helm.sh/chart: qbittorrent-7.1.0
    app.kubernetes.io/name: generic-device-plugin
    app.kubernetes.io/instance: qbittorrent-1783882233
    app.kubernetes.io/version: "5.2.3"
    app.kubernetes.io/part-of: qbittorrent
    app.kubernetes.io/managed-by: Helm
spec:
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/name: generic-device-plugin
      app.kubernetes.io/instance: qbittorrent-1783882233
  template:
    metadata:
      labels:
        helm.sh/chart: qbittorrent-7.1.0
        app.kubernetes.io/name: generic-device-plugin
        app.kubernetes.io/instance: qbittorrent-1783882233
        app.kubernetes.io/version: "5.2.3"
        app.kubernetes.io/part-of: qbittorrent
        app.kubernetes.io/managed-by: Helm
    spec:
      priorityClassName: system-node-critical
      serviceAccountName: qbittorrent-1783882233-generic-device-plugin
      securityContext:
        {}
      containers:
        - name: generic-device-plugin
          securityContext:
            privileged: true
          image: "ghcr.io/squat/generic-device-plugin:0.2.0"
          imagePullPolicy: 
          # count: 1024 is arbitrary, but will limit each k8s node
          # to only running 1024 containers that use /dev/net/tun
          args:
          - --device
          - |
            name: tun
            groups:
              - count: 1024
                paths:
                  - path: /dev/net/tun
          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /health
              port: http
          readinessProbe:
            httpGet:
              path: /health
              port: http
          resources:
            {}
          volumeMounts:
            - name: device-plugin
              mountPath: /var/lib/kubelet/device-plugins
            - name: dev
              mountPath: /dev
      volumes:
        - name: device-plugin
          hostPath:
            path: /var/lib/kubelet/device-plugins
        - name: dev
          hostPath:
            path: /dev
---
# Source: qbittorrent/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: qbittorrent-1783882233
  namespace: default
  labels:
    helm.sh/chart: qbittorrent-7.1.0
    app.kubernetes.io/name: qbittorrent
    app.kubernetes.io/instance: qbittorrent-1783882233
    app.kubernetes.io/version: "5.2.3"
    app.kubernetes.io/part-of: qbittorrent
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app.kubernetes.io/name: qbittorrent
      app.kubernetes.io/instance: qbittorrent-1783882233
  template:
    metadata:
      labels:
        helm.sh/chart: qbittorrent-7.1.0
        app.kubernetes.io/name: qbittorrent
        app.kubernetes.io/instance: qbittorrent-1783882233
        app.kubernetes.io/version: "5.2.3"
        app.kubernetes.io/part-of: qbittorrent
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: qbittorrent-1783882233
      securityContext:
        fsGroup: 65534
        fsGroupChangePolicy: OnRootMismatch
      containers:
        - name: qbittorrent
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsGroup: 65534
            runAsNonRoot: true
            runAsUser: 65534
            seccompProfile:
              type: RuntimeDefault
          image: "ghcr.io/home-operations/qbittorrent:5.2.3"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
            - name: torrent-tcp
              containerPort: 50413
              protocol: TCP
            - name: torrent-udp
              containerPort: 50413
              protocol: UDP
          livenessProbe:
            exec:
              command:
                - sh
                - -c
                - "wget --no-verbose --tries=1 --spider http://localhost:8080 || exit 1"
          readinessProbe:
            exec:
              command:
                - sh
                - -c
                - "wget --no-verbose --tries=1 --spider http://localhost:8080 || exit 1"
          resources:
            {}
          volumeMounts:
            - name: config
              mountPath: /config
      volumes:
        - name: config
          persistentVolumeClaim:
            claimName: qbittorrent-1783882233-config

NOTES:
***********************************************************************
 Welcome to qbittorrent
 Chart version: 7.1.0
 App   version: 5.2.3
***********************************************************************
➜  helm-charts git:(qbittorrent-service-labels) ✗ helm lint charts/qbittorrent 
==> Linting charts/qbittorrent

1 chart(s) linted, 0 chart(s) failed
```
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have read and followed the contribution [guidelines](../CONTRIBUTING.md).
- [ x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->
<!--- Thank you for contributing to helm-charts! 🚀  -->